### PR TITLE
Update list of limitations and correct spelling.

### DIFF
--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -16,7 +16,6 @@ In particular, many PDBx categories pertaining to experimentally-determined
 structures are ignored. Also, the following ModelCIF categories are currently
 not supported:
 
- - ``ma_template_non_poly``
  - ``ma_template_customized``
  - ``ma_template_coord``
  - ``ma_coevolution_seq_db_ref``

--- a/modelcif/alignment.py
+++ b/modelcif/alignment.py
@@ -136,7 +136,7 @@ class Score(object):
 
        :param float value: The actual score value.
     """
-    type = "other"
+    type = "Other"
 
     def __init__(self, value):
         self.value = value


### PR DESCRIPTION
Since `ma_template_non_poly` is now available, it could be removed from the list of limitations.
The "other" value of `ma_alignment_details.score_type`is spelled "Other" (with an uppercase O) in the [ModelCIF dictionary](https://mmcif.wwpdb.org/dictionaries/mmcif_ma.dic/Items/_ma_alignment_details.score_type.html).