### PR TITLE
Add _ma_target_ref_db_details.[seq_db_sequence_version_date, seq_db_sequence_checksum]

### DIFF
--- a/modelcif/dumper.py
+++ b/modelcif/dumper.py
@@ -1,5 +1,6 @@
 """Utility classes to dump out information in mmCIF or BinaryCIF format"""
 
+from datetime import date
 import itertools
 import operator
 import ihm.dumper
@@ -52,7 +53,8 @@ class _TargetRefDBDumper(Dumper):
                 ["target_entity_id", "db_name", "db_name_other_details",
                  "db_code", "db_accession", "seq_db_isoform",
                  "seq_db_align_begin", "seq_db_align_end",
-                 "ncbi_taxonomy_id", "organism_scientific"]) as lp:
+                 "ncbi_taxonomy_id", "organism_scientific",
+                 "seq_db_sequence_version_date"]) as lp:
             for e in entities:
                 for r in e.references:
                     db_begin = (e.seq_id_range[0] if r.align_begin is None
@@ -66,7 +68,10 @@ class _TargetRefDBDumper(Dumper):
                              seq_db_align_begin=db_begin,
                              seq_db_align_end=db_end,
                              ncbi_taxonomy_id=r.ncbi_taxonomy_id,
-                             organism_scientific=r.organism_scientific)
+                             organism_scientific=r.organism_scientific,
+                             seq_db_sequence_version_date=date.isoformat(
+                                 r.sequence_version_date)
+                             if r.sequence_version_date else None)
 
 
 class _EntityNonPolyDumper(Dumper):

--- a/modelcif/reader.py
+++ b/modelcif/reader.py
@@ -273,7 +273,8 @@ class _TargetRefDBHandler(Handler):
                   align_end=self.get_int(seq_db_align_end),
                   isoform=seq_db_isoform, ncbi_taxonomy_id=ncbi_taxonomy_id,
                   organism_scientific=organism_scientific,
-                  sequence_version_date=self.get_date(seq_db_sequence_version_date))
+                  sequence_version_date=self.get_date(
+                      seq_db_sequence_version_date))
         e.references.append(ref)
 
 

--- a/modelcif/reader.py
+++ b/modelcif/reader.py
@@ -12,6 +12,7 @@ import ihm.source
 import ihm.reader
 from ihm.reader import Variant, Handler, IDMapper, _ChemCompIDMapper
 from ihm.reader import OldFileError, _make_new_entity
+from datetime import date
 import posixpath
 import operator
 import inspect
@@ -253,16 +254,26 @@ class _TargetRefDBHandler(Handler):
         self.type_map = _EnumerationMapper(modelcif.reference,
                                            modelcif.reference.TargetReference)
 
+    def get_date(self, iso_date_str):
+        """Get a datetime.date obj for a string in isoformat."""
+        if iso_date_str is None:
+            return None
+        return date(int(iso_date_str[0:4]),
+                    int(iso_date_str[5:7]),
+                    int(iso_date_str[8:10]))
+
     def __call__(self, target_entity_id, db_name, db_name_other_details,
                  db_code, db_accession, seq_db_isoform, seq_db_align_begin,
-                 seq_db_align_end, ncbi_taxonomy_id, organism_scientific):
+                 seq_db_align_end, ncbi_taxonomy_id, organism_scientific,
+                 seq_db_sequence_version_date):
         e = self.sysr.entities.get_by_id(target_entity_id)
         typ = self.type_map.get(db_name, db_name_other_details)
         ref = typ(code=db_code, accession=db_accession,
                   align_begin=self.get_int(seq_db_align_begin),
                   align_end=self.get_int(seq_db_align_end),
                   isoform=seq_db_isoform, ncbi_taxonomy_id=ncbi_taxonomy_id,
-                  organism_scientific=organism_scientific)
+                  organism_scientific=organism_scientific,
+                  sequence_version_date=self.get_date(seq_db_sequence_version_date))
         e.references.append(ref)
 
 

--- a/modelcif/reference.py
+++ b/modelcif/reference.py
@@ -21,18 +21,24 @@ class TargetReference(object):
        :param str isoform: Sequence isoform, if applicable.
        :param str ncbi_taxonomy_id: Taxonomy identifier provided by NCBI.
        :param str organism_scientific: Scientific name of the organism.
+       :param sequence_version_date: Versioning date, e.g. for UniProtKB
+                                     sequences this is usually the date of last
+                                     modification from the DT line of an entry.
+       :type sequence_version_date: :class:`datetime.date` or
+                                    :class:`datetime.datetime`
     """
 
     name = 'Other'
 
     def __init__(self, code, accession, align_begin=None, align_end=None,
                  isoform=None, ncbi_taxonomy_id=None,
-                 organism_scientific=None):
+                 organism_scientific=None, sequence_version_date=None):
         self.code, self.accession = code, accession
         self.align_begin, self.align_end = align_begin, align_end
         self.isoform = isoform
         self.ncbi_taxonomy_id = ncbi_taxonomy_id
         self.organism_scientific = organism_scientific
+        self.sequence_version_date = sequence_version_date
 
     def _get_other_details(self):
         if (type(self) is not TargetReference

--- a/test/test_dumper.py
+++ b/test/test_dumper.py
@@ -1,3 +1,4 @@
+from datetime import date
 import utils
 import os
 import unittest
@@ -434,7 +435,8 @@ C
         ref1 = modelcif.reference.UniProt(
             code='testcode', accession='testacc', align_begin=4, align_end=8,
             isoform='testiso', ncbi_taxonomy_id='1234',
-            organism_scientific='testorg')
+            organism_scientific='testorg',
+            sequence_version_date=date(1979, 11, 22))
         ref2 = modelcif.reference.UniProt(code='c2', accession='a2')
         ref3 = CustomRef(code='c3', accession='a3', isoform=ihm.unknown)
 
@@ -457,9 +459,10 @@ _ma_target_ref_db_details.seq_db_align_begin
 _ma_target_ref_db_details.seq_db_align_end
 _ma_target_ref_db_details.ncbi_taxonomy_id
 _ma_target_ref_db_details.organism_scientific
-1 UNP . testcode testacc testiso 4 8 1234 testorg
-1 UNP . c2 a2 . 1 4 . .
-1 Other 'my custom ref' c3 a3 ? 1 4 . .
+_ma_target_ref_db_details.seq_db_sequence_version_date
+1 UNP . testcode testacc testiso 4 8 1234 testorg 1979-11-22
+1 UNP . c2 a2 . 1 4 . . .
+1 Other 'my custom ref' c3 a3 ? 1 4 . . .
 #
 """)
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -40,7 +40,7 @@ class Tests(unittest.TestCase):
             # can read it
             with open(os.path.join(tmpdir, 'output.cif')) as fh:
                 contents = fh.readlines()
-            self.assertEqual(len(contents), 445)
+            self.assertEqual(len(contents), 446)
             with open(os.path.join(tmpdir, 'output.cif')) as fh:
                 s, = modelcif.reader.read(fh)
 

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -1,3 +1,4 @@
+from datetime import date
 import sys
 import unittest
 import utils
@@ -152,10 +153,11 @@ _ma_target_ref_db_details.seq_db_align_begin
 _ma_target_ref_db_details.seq_db_align_end
 _ma_target_ref_db_details.ncbi_taxonomy_id
 _ma_target_ref_db_details.organism_scientific
-1 UNP . MED1_YEAST Q12321 test_iso 1 10 test_tax test_org
-1 Other foo . . ? 1 10 . .
-1 other bar . . ? 1 10 . .
-1 MIS baz . . ? 1 10 . .
+_ma_target_ref_db_details.seq_db_sequence_version_date
+1 UNP . MED1_YEAST Q12321 test_iso 1 10 test_tax test_org 1979-11-22
+1 Other foo . . ? 1 10 . . .
+1 other bar . . ? 1 10 . . .
+1 MIS baz . . ? 1 10 . . .
 """
         s, = modelcif.reader.read(StringIO(cif))
         e, = s.entities
@@ -168,6 +170,7 @@ _ma_target_ref_db_details.organism_scientific
         self.assertEqual(r1.align_end, 10)
         self.assertEqual(r1.ncbi_taxonomy_id, 'test_tax')
         self.assertEqual(r1.organism_scientific, 'test_org')
+        self.assertEqual(r1.sequence_version_date, date(1979, 11, 22))
         self.assertEqual(r2.name, 'Other')
         self.assertEqual(r2.other_details, 'foo')
         self.assertEqual(r3.name, 'Other')


### PR DESCRIPTION
Add two more data items to `_ma_target_ref_db_details`. The version date is kept as `datetime.date` object, allowing `python-modelcif` to apply the right formatting. The CRC64 checksum is not computed by `python-modelcif` because I'm not sure if we will always see the complete sequence and it would make reading it in a bit more complicated. Unit tests & documentation should work. Has a merge conflict with https://github.com/ihmwg/python-modelcif/pull/14 , that is a number to be increased in `test/test_examples.py`. 