### PR TITLE
Add modelcif.reference.template references

### DIFF
--- a/modelcif/reference.py
+++ b/modelcif/reference.py
@@ -115,3 +115,28 @@ class PDB(TemplateReference):
     """
     name = 'PDB'
     other_details = None
+
+
+class AlphaFoldDB(TemplateReference):
+    """Point to the structure of a :class:`modelcif.Template` in AlphaFold DB.
+
+       These objects are typically passed to the :class:`modelcif.Template`
+       constructor.
+
+       See :class:`TemplateReference` for a description of the parameters.
+    """
+    name = 'AlphaFoldDB'
+    other_details = None
+
+
+class PubChem(TemplateReference):
+    """Point to the structure of a :class:`modelcif.Template` in PubChem.
+
+       These objects are typically passed to the :class:`modelcif.Template`
+       constructor.
+
+       See :class:`TemplateReference` for a description of the parameters. Use
+       the PubChem CID ass accession code.
+    """
+    name = 'PubChem'
+    other_details = None

--- a/test/test_dumper.py
+++ b/test/test_dumper.py
@@ -539,10 +539,13 @@ _ma_target_ref_db_details.seq_db_sequence_checksum
         system.asym_units.append(asym)
         ref1 = modelcif.reference.PDB('1abc')
         ref2 = CustomRef('2xyz')
+        ref3 = modelcif.reference.PubChem("1234")
+        ref4 = modelcif.reference.AlphaFoldDB("P12345")
         tr = modelcif.Transformation.identity()
         tr._id = 42
         t = modelcif.Template(tmp_e, asym_id='H', model_num=1, name='testtmp',
-                              transformation=tr, references=[ref1, ref2],
+                              transformation=tr,
+                              references=[ref1, ref2, ref3, ref4],
                               strand_id='Z')
         t._data_id = 99
         p = modelcif.alignment.Pair(
@@ -600,6 +603,8 @@ _ma_template_ref_db_details.db_name_other_details
 _ma_template_ref_db_details.db_accession_code
 1 PDB . 1abc
 1 Other 'my custom ref' 2xyz
+1 PubChem . 1234
+1 AlphaFoldDB . P12345
 #
 #
 loop_

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -290,16 +290,22 @@ _ma_template_ref_db_details.db_accession_code
 1 PDB . 3nc1
 1 MIS . testacc
 1 Other foo acc2
+1 PubChem . 1046
+1 AlphaFoldDB . I6XD65
 """
         s, = modelcif.reader.read(StringIO(cif))
         t, = s.templates
-        r1, r2, r3 = t.references
+        r1, r2, r3, r4, r5 = t.references
         self.assertIsInstance(r1, modelcif.reference.PDB)
         self.assertEqual(r1.accession, '3nc1')
         self.assertEqual(r2.name, 'MIS')
         self.assertIsNone(r2.other_details)
         self.assertEqual(r3.name, 'Other')
         self.assertEqual(r3.other_details, 'foo')
+        self.assertIsInstance(r4, modelcif.reference.PubChem)
+        self.assertEqual(r4.accession, '1046')
+        self.assertIsInstance(r5, modelcif.reference.AlphaFoldDB)
+        self.assertEqual(r5.accession, 'I6XD65')
 
     def _get_models_cif(self):
         cif = """


### PR DESCRIPTION
Adds the new `_ma_target_ref_db_details.db_name` entries from ModelCIF dictionary version 1.4.1 to `modelcif.references`.