### PR TITLE
Add _ma_template_ref_db_details.db_version_date.

### DIFF
--- a/modelcif/dumper.py
+++ b/modelcif/dumper.py
@@ -454,12 +454,15 @@ class _AlignmentDumper(Dumper):
         with writer.loop(
                 "_ma_template_ref_db_details",
                 ["template_id", "db_name", "db_name_other_details",
-                 "db_accession_code"]) as lp:
+                 "db_accession_code", "db_version_date"]) as lp:
             for tmpl in system.templates:
                 for ref in tmpl.references:
                     lp.write(template_id=tmpl._id, db_name=ref.name,
                              db_name_other_details=ref.other_details,
-                             db_accession_code=ref.accession)
+                             db_accession_code=ref.accession,
+                             db_version_date=date.isoformat(
+                                 ref.db_version_date)
+                             if ref.db_version_date else None)
 
     def dump_target_template_poly_mapping(self, system, writer):
         ordinal = itertools.count(1)

--- a/modelcif/reader.py
+++ b/modelcif/reader.py
@@ -448,10 +448,11 @@ class _TemplateRefDBHandler(Handler):
             modelcif.reference, modelcif.reference.TemplateReference)
 
     def __call__(self, template_id, db_name, db_name_other_details,
-                 db_accession_code):
+                 db_accession_code, db_version_date):
         t = self.sysr.templates.get_by_id(template_id)
         typ = self.type_map.get(db_name, db_name_other_details)
-        ref = typ(accession=db_accession_code)
+        ref = typ(accession=db_accession_code,
+                  db_version_date=_get_date(db_version_date))
         t.references.append(ref)
 
 

--- a/modelcif/reference.py
+++ b/modelcif/reference.py
@@ -88,11 +88,17 @@ class TemplateReference(object):
                "my custom database"
 
        :param str accession: The database accession.
+       :param db_version_date: Versioning date, e.g. for PDB entries this is
+                               usually the value of
+                               ``_pdbx_audit_revision_history.revision_date``.
+       :type db_version_date: :class:`datetime.date` or
+                              :class:`datetime.datetime`
     """
     name = 'Other'
 
-    def __init__(self, accession):
+    def __init__(self, accession, db_version_date=None):
         self.accession = accession
+        self.db_version_date = db_version_date
 
     def _get_other_details(self):
         if (type(self) is not TemplateReference

--- a/test/test_dumper.py
+++ b/test/test_dumper.py
@@ -537,10 +537,12 @@ _ma_target_ref_db_details.seq_db_sequence_checksum
         asym = modelcif.AsymUnit(tgt_e, id='A')
         asym._id = 'A'
         system.asym_units.append(asym)
-        ref1 = modelcif.reference.PDB('1abc')
+        ref1 = modelcif.reference.PDB('1abc',
+                                      db_version_date=date(1979, 11, 22))
         ref2 = CustomRef('2xyz')
         ref3 = modelcif.reference.PubChem("1234")
-        ref4 = modelcif.reference.AlphaFoldDB("P12345")
+        ref4 = modelcif.reference.AlphaFoldDB("P12345",
+                                              db_version_date=date(2022, 6, 1))
         tr = modelcif.Transformation.identity()
         tr._id = 42
         t = modelcif.Template(tmp_e, asym_id='H', model_num=1, name='testtmp',
@@ -611,10 +613,11 @@ _ma_template_ref_db_details.template_id
 _ma_template_ref_db_details.db_name
 _ma_template_ref_db_details.db_name_other_details
 _ma_template_ref_db_details.db_accession_code
-1 PDB . 1abc
-1 Other 'my custom ref' 2xyz
-1 PubChem . 1234
-1 AlphaFoldDB . P12345
+_ma_template_ref_db_details.db_version_date
+1 PDB . 1abc 1979-11-22
+1 Other 'my custom ref' 2xyz .
+1 PubChem . 1234 .
+1 AlphaFoldDB . P12345 2022-06-01
 #
 #
 loop_

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -40,7 +40,7 @@ class Tests(unittest.TestCase):
             # can read it
             with open(os.path.join(tmpdir, 'output.cif')) as fh:
                 contents = fh.readlines()
-            self.assertEqual(len(contents), 418)
+            self.assertEqual(len(contents), 419)
             with open(os.path.join(tmpdir, 'output.cif')) as fh:
                 s, = modelcif.reader.read(fh)
 
@@ -55,7 +55,7 @@ class Tests(unittest.TestCase):
             # can read it
             with open(os.path.join(tmpdir, 'output.cif')) as fh:
                 contents = fh.readlines()
-            self.assertEqual(len(contents), 324)
+            self.assertEqual(len(contents), 325)
             with open(os.path.join(tmpdir, 'output.cif')) as fh:
                 s, = modelcif.reader.read(fh)
 

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -287,25 +287,29 @@ _ma_template_ref_db_details.template_id
 _ma_template_ref_db_details.db_name
 _ma_template_ref_db_details.db_name_other_details
 _ma_template_ref_db_details.db_accession_code
-1 PDB . 3nc1
-1 MIS . testacc
-1 Other foo acc2
-1 PubChem . 1046
-1 AlphaFoldDB . I6XD65
+_ma_template_ref_db_details.db_version_date
+1 PDB . 3nc1 2021-10-06
+1 MIS . testacc .
+1 Other foo acc2 .
+1 PubChem . 1046 .
+1 AlphaFoldDB . I6XD65 2022-06-01
 """
         s, = modelcif.reader.read(StringIO(cif))
         t, = s.templates
         r1, r2, r3, r4, r5 = t.references
         self.assertIsInstance(r1, modelcif.reference.PDB)
         self.assertEqual(r1.accession, '3nc1')
+        self.assertEqual(r1.db_version_date, date(2021, 10, 6))
         self.assertEqual(r2.name, 'MIS')
         self.assertIsNone(r2.other_details)
+        self.assertIsNone(r2.db_version_date)
         self.assertEqual(r3.name, 'Other')
         self.assertEqual(r3.other_details, 'foo')
         self.assertIsInstance(r4, modelcif.reference.PubChem)
         self.assertEqual(r4.accession, '1046')
         self.assertIsInstance(r5, modelcif.reference.AlphaFoldDB)
         self.assertEqual(r5.accession, 'I6XD65')
+        self.assertEqual(r5.db_version_date, date(2022, 6, 1))
 
     def _get_models_cif(self):
         cif = """


### PR DESCRIPTION
Enable [`_ma_template_ref_db_details.db_version_date`](https://mmcif.wwpdb.org/dictionaries/mmcif_ma.dic/Items/_ma_template_ref_db_details.db_version_date.html) in the `dumper` and the `reader`.