### PR TITLE
Build a wheel

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -21,8 +21,8 @@
 #   in the pypi package)
 
 VERSION=$(python3 setup.py --version)
-python3 setup.py sdist
-echo "Now use 'twine upload dist/modelcif-${VERSION}.tar.gz' to publish the release on PyPi"
+python3 -m build
+echo "Now use 'twine upload dist/modelcif-${VERSION}*' to publish the release on PyPi"
 echo "Then, update the conda-forge and COPR packages to match."
 echo "For COPR, use dist/modelcif-${VERSION}.tar.gz together with util/python-modelcif.spec"
 echo "For conda-forge, make sure the correct version of python-ihm is required"


### PR DESCRIPTION
Build and publish a wheel, as well as a source distribution

You will need to `pip install build` first, just as you must `pip install twine` before publishing